### PR TITLE
Fix deprecated timer usage

### DIFF
--- a/Bic.py
+++ b/Bic.py
@@ -23,7 +23,7 @@ from math import log10, floor
 import Load
 import Print
 
-start_time = time.clock()
+start_time = time.perf_counter()
 
 def main(address, filename_raw_data, subsample_bic, repeat_bic, max_groups, grid_bic,\
          conc_bic, size_bic, n_dimen, fraction_nan_samples, fraction_nan_depths, cov_type):
@@ -118,4 +118,4 @@ def bic_calculate(X, max_groups, cov_type):
     bic_score = np.asarray(bic_score).reshape(1,-1)
     return bic_score, lowest_n, n_components_range
 
-print('BIC runtime = ', time.clock() - start_time,' s')
+print('BIC runtime = ', time.perf_counter() - start_time,' s')

--- a/GMM.py
+++ b/GMM.py
@@ -19,7 +19,7 @@ import time
 import ClassProperties
 import Print
 
-start_time = time.clock()
+start_time = time.perf_counter()
 
 def create(address, runIndex, n_comp, cov_type):
     print("GMM.create")
@@ -112,4 +112,4 @@ def GaussianMixtureModel(address, runIndex, n_comp, X_train, cov_type):
     
     return gmm, weights, means, covariances
 
-print('GMM runtime = ', time.clock() - start_time,' s')
+print('GMM runtime = ', time.perf_counter() - start_time,' s')

--- a/Load.py
+++ b/Load.py
@@ -22,7 +22,7 @@ import time
 
 import Print
 
-start_time = time.clock()
+start_time = time.perf_counter()
 
 def main(address, filename_raw_data, runIndex, subsample_uniform, subsample_random,\
          subsample_inTime, grid, conc, fraction_train, inTime_start, inTime_finish,\
@@ -383,4 +383,4 @@ def centreAndStandardise(address, runIndex, VAR):
     
     return stand, stand_store, var_stand
     
-print('Load runtime = ', time.clock() - start_time,' s')
+print('Load runtime = ', time.perf_counter() - start_time,' s')

--- a/Main.py
+++ b/Main.py
@@ -40,7 +40,7 @@ import os.path
 import pdb
 
 # start the clock (performance timing)
-start_time = time.clock()
+start_time = time.perf_counter()
 
 # set run mode (BIC, GMM, or Plot)
 # -- BIC = calculates BIC scores for a range of classes
@@ -288,5 +288,5 @@ else:
     print('Parameter run_mode not set properly. Check Main.py')
 
 # print runtime for performance
-print('Main runtime = ', time.clock() - start_time,' s')
+print('Main runtime = ', time.perf_counter() - start_time,' s')
     

--- a/PCA.py
+++ b/PCA.py
@@ -22,7 +22,7 @@ import time
 
 import Print
 
-start_time = time.clock()
+start_time = time.perf_counter()
 
 def create(address, runIndex, n_dimen, use_fPCA):
     print("Entering function PCA.create")
@@ -119,7 +119,7 @@ def PrincipalComponentAnalysis(address, runIndex, X_train, \
     
     return pca, pca_store, X_pca_train, variance_sum
 
-print('PCA runtime = ', time.clock() - start_time,' s')
+print('PCA runtime = ', time.perf_counter() - start_time,' s')
 
 ###############################################################################  
 

--- a/Plot.py
+++ b/Plot.py
@@ -30,7 +30,7 @@ import cartopy.feature as cfeature
 import Print
 import time
 
-start_time = time.clock()
+start_time = time.perf_counter()
 
 def plotMapCircular(address, address_fronts, plotFronts, n_comp, allDF, colormap):
     print("Plot.plotMapCircular")
@@ -901,4 +901,4 @@ def plotPCAmplitudeCoefficients(address, address_fronts, runIndex):
 
 ###########
 
-print('Plot runtime = ', time.clock() - start_time,' s')
+print('Plot runtime = ', time.perf_counter() - start_time,' s')

--- a/Print.py
+++ b/Print.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import os.path
 import csv
 
-start_time = time.clock()
+start_time = time.perf_counter()
 
 separator = ','
 
@@ -838,4 +838,4 @@ def readReconstruction(address, runIndex, depth, isTrain):
     return lon, lat, dynHeight, X_array, X_array_centred, varTime
         
     
-print('Printing runtime = ', time.clock() - start_time,' s')
+print('Printing runtime = ', time.perf_counter() - start_time,' s')

--- a/Reconstruct.py
+++ b/Reconstruct.py
@@ -22,7 +22,7 @@ import time
 
 import Print
 
-start_time = time.clock()
+start_time = time.perf_counter()
 
 def gmm_reconstruct(address, runIndex, n_comp):
     print("Reconstruct.gmm_reconstruct")
@@ -154,4 +154,4 @@ def full_reconstruct(address, runIndex):
     Print.printReconstruction(address, runIndex, lon, lat, dynHeight,\
                               XR, XRC, varTime, depth, False)
 
-print('Reconstruct runtime = ', time.clock() - start_time,' s')
+print('Reconstruct runtime = ', time.perf_counter() - start_time,' s')


### PR DESCRIPTION
## Summary
- replace deprecated `time.clock()` with `time.perf_counter()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421b6c8dcc832ca2e3ad42055605e8